### PR TITLE
CMUpdater: Show updates only for the channel a user is on

### DIFF
--- a/src/com/cyanogenmod/updater/misc/Constants.java
+++ b/src/com/cyanogenmod/updater/misc/Constants.java
@@ -33,9 +33,13 @@ public class Constants {
     // Update types
     public static final int UPDATE_TYPE_SNAPSHOT = 0;
     public static final int UPDATE_TYPE_NIGHTLY = 1;
+    public static final int UPDATE_TYPE_EXPERIMENTAL = 2;
+    public static final int UPDATE_TYPE_UNOFFICIAL = 3;
 
     // ro.cm.releasetype values
     public static final String PROPERTY_CM_RELEASETYPE = "ro.cm.releasetype";
     public static final String CM_RELEASETYPE_SNAPSHOT = "SNAPSHOT";
     public static final String CM_RELEASETYPE_NIGHTLY = "NIGHTLY";
+    public static final String CM_RELEASETYPE_EXPERIMENTAL = "EXPERIMENTAL";
+    public static final String CM_RELEASETYPE_UNOFFICIAL = "UNOFFICIAL";
 }

--- a/src/com/cyanogenmod/updater/service/UpdateCheckService.java
+++ b/src/com/cyanogenmod/updater/service/UpdateCheckService.java
@@ -205,14 +205,23 @@ public class UpdateCheckService extends IntentService
     }
 
     private String getRomType() {
-        int updateType = Utils.getUpdateType();
-        switch(updateType) {
+        String type;
+        switch (Utils.getUpdateType()) {
             case Constants.UPDATE_TYPE_SNAPSHOT:
-                return "snapshot";
+                type = Constants.CM_RELEASETYPE_SNAPSHOT;
+                break;
             case Constants.UPDATE_TYPE_NIGHTLY:
+                type = Constants.CM_RELEASETYPE_NIGHTLY;
+                break;
+            case Constants.UPDATE_TYPE_EXPERIMENTAL:
+                type = Constants.CM_RELEASETYPE_EXPERIMENTAL;
+                break;
+            case Constants.UPDATE_TYPE_UNOFFICIAL:
             default:
-                return "nightly";
+                type = Constants.CM_RELEASETYPE_UNOFFICIAL;
+                break;
         }
+        return type.toLowerCase();
     }
 
     private URI getServerURI() {

--- a/src/com/cyanogenmod/updater/utils/Utils.java
+++ b/src/com/cyanogenmod/updater/utils/Utils.java
@@ -153,21 +153,29 @@ public class Utils {
     }
 
     public static int getUpdateType() {
-        int updateType = Constants.UPDATE_TYPE_NIGHTLY;
+        String releaseType;
         try {
-            String cmReleaseType = SystemProperties.get(
-                    Constants.PROPERTY_CM_RELEASETYPE);
-
-            // Treat anything that is not SNAPSHOT as NIGHTLY
-            if (!cmReleaseType.isEmpty()) {
-                if (TextUtils.equals(cmReleaseType,
-                        Constants.CM_RELEASETYPE_SNAPSHOT)) {
-                    updateType = Constants.UPDATE_TYPE_SNAPSHOT;
-                }
-            }
-        } catch (RuntimeException ignored) {
+            releaseType = SystemProperties.get(Constants.PROPERTY_CM_RELEASETYPE);
+        } catch (IllegalArgumentException e) {
+            releaseType = Constants.CM_RELEASETYPE_UNOFFICIAL;
         }
 
+        int updateType;
+        switch (releaseType) {
+            case Constants.CM_RELEASETYPE_SNAPSHOT:
+                updateType = Constants.UPDATE_TYPE_SNAPSHOT;
+                break;
+            case Constants.CM_RELEASETYPE_NIGHTLY:
+                updateType = Constants.UPDATE_TYPE_NIGHTLY;
+                break;
+            case Constants.CM_RELEASETYPE_EXPERIMENTAL:
+                updateType = Constants.UPDATE_TYPE_EXPERIMENTAL;
+                break;
+            case Constants.CM_RELEASETYPE_UNOFFICIAL:
+            default:
+                updateType = Constants.UPDATE_TYPE_UNOFFICIAL;
+                break;
+        }
         return updateType;
     }
 }


### PR DESCRIPTION
Previously, we were displaying updates for the nightly channel,
even when the user is on an experimental or unofficial build.

We can't do this anymore for two reasons:
 - People doing unofficial updates are using our (now) open
   source updater service
 - Going from unofficial->nightly is no longer a valid option

Change-Id: I8e365b61237ab85ac10908efb51170206854f83c