### PR TITLE
Fix dates of downloaded and installed builds

### DIFF
--- a/src/com/cyanogenmod/updater/UpdatePreference.java
+++ b/src/com/cyanogenmod/updater/UpdatePreference.java
@@ -107,7 +107,7 @@ public class UpdatePreference extends Preference implements OnClickListener, OnL
         // We only show updates of type Utils.getUpdateType(), so just use that here
         mBuildType = Utils.buildTypeToString(Utils.getUpdateType()).toLowerCase();
         mBuildVersionName = Utils.getInstalledVersionName();
-        mBuildDateString = Utils.getDateLocalized(mContext, mUpdateInfo.getDate());
+        mBuildDateString = Utils.getDateLocalizedFromFileName(mContext, mUpdateInfo.getFileName());
 
         // Store the views from the layout
         mTitleText = (TextView)view.findViewById(R.id.title);

--- a/src/com/cyanogenmod/updater/utils/Utils.java
+++ b/src/com/cyanogenmod/updater/utils/Utils.java
@@ -22,6 +22,7 @@ import android.net.NetworkInfo;
 import android.os.Build;
 import android.os.SystemProperties;
 import android.preference.PreferenceManager;
+import android.util.Log;
 
 import com.cyanogenmod.updater.R;
 import com.cyanogenmod.updater.misc.Constants;
@@ -30,11 +31,15 @@ import com.cyanogenmod.updater.service.UpdateCheckService;
 import java.io.File;
 import java.io.IOException;
 import java.text.DateFormat;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
 public class Utils {
+
+    private static final String TAG = "Utils";
+
     private Utils() {
         // this class is not supposed to be instantiated
     }
@@ -79,6 +84,29 @@ public class Utils {
         f.setTimeZone(TimeZone.getTimeZone("UTC"));
         Date date = new Date(unixTimestamp * 1000);
         return f.format(date);
+    }
+
+    public static String getDateLocalizedFromFileName(Context context, String fileName) {
+        return getDateLocalized(context, getTimestampFromFileName(fileName));
+    }
+
+    public static long getTimestampFromFileName(String fileName) {
+        String[] subStrings = fileName.split("-");
+        if (subStrings.length < 3 || subStrings[2].length() < 8) {
+            Log.e(TAG, "The given filename is not valid: " + fileName);
+            return 0;
+        }
+        try {
+            int year = Integer.parseInt(subStrings[2].substring(0, 4));
+            int month = Integer.parseInt(subStrings[2].substring(4, 6)) - 1;
+            int day = Integer.parseInt(subStrings[2].substring(6, 8));
+            Calendar cal = Calendar.getInstance();
+            cal.set(year, month, day);
+            return cal.getTimeInMillis() / 1000;
+        } catch (NumberFormatException e) {
+            Log.e(TAG, "The given filename is not valid: " + fileName);
+            return 0;
+        }
     }
 
     public static String getAndroidVersion(String versionName) {


### PR DESCRIPTION
With commit 30b0384ba125 ("Move properties parsing logic inside Utils")
it was assumed that getDate() returns a proper timestamp for all the
files, but this is only true for builds not yet downloaded. For all
the other builds the returned value is 0, so try to get the date from
the file name, which has a known structure.

Change-Id: Id61fc9a45f206f5ce8020ac845610c2c0fb9a90d