### PR TITLE
CMUpdater: Strip 'signed' from UI Name

### DIFF
--- a/src/com/cyanogenmod/updater/misc/UpdateInfo.java
+++ b/src/com/cyanogenmod/updater/misc/UpdateInfo.java
@@ -154,7 +154,7 @@ public class UpdateInfo implements Parcelable, Serializable {
 
     public static String extractUiName(String fileName) {
         String deviceType = Utils.getDeviceType();
-        String uiName = fileName.replaceAll("\\.zip$", "");
+        String uiName = fileName.replaceAll("(-signed)?\\.zip$", "");
         return uiName.replaceAll("-" + deviceType + "-?", "");
     }
 


### PR DESCRIPTION
Remove '-signed' from string used to identify the update in the user
interface.

Change-Id: I7329abb551375332e4fa57e179000889e5ef81a3